### PR TITLE
retry demo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,15 +2,22 @@ on: push
 name: golang-ci
 jobs:
   checks:
-    name: run
+    name: run-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - name: run
-        uses: cedrickring/golang-action@1.5.2
+
+      - name: Use Go 1.15
+        uses: cedrickring/golang-action@1.6.0
         env:
           GO111MODULE: "on"
-      - name: Use Go 1.13
-        uses: cedrickring/golang-action/go1.13@1.5.2
+
+      - name: Use Go 1.14
+        uses: cedrickring/golang-action/go1.14@1.6.0
         env:
-            GO111MODULE: "on"
+          GO111MODULE: "on"
+
+      - name: Use Go 1.13
+        uses: cedrickring/golang-action/go1.13@1.6.0
+        env:
+          GO111MODULE: "on"

--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -1,0 +1,11 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  golangci-lint:
+    name: runner / golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v1

--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ FastWeGo 是一套完整的微信开发框架，包括公众号、开放平台�
 欢迎提交 pull request / issue / 文档，一起让微信开发更快更好！
 
 Faster we go together!
+
+[加入开发者交流群](https://github.com/fastwego/fastwego.dev)

--- a/apis/oauth/oauth.go
+++ b/apis/oauth/oauth.go
@@ -94,6 +94,7 @@ func GetAccessToken(appid string, secret string, code string) (oauthAccessToken 
 	params.Add("appid", appid)
 	params.Add("secret", secret)
 	params.Add("code", code)
+	params.Add("grant_type", "authorization_code")
 
 	uri := offiaccount.WXServerUrl + apiAccessToken + "?" + params.Encode()
 	response, err := http.Get(uri)

--- a/apis/oauth/oauth.go
+++ b/apis/oauth/oauth.go
@@ -62,11 +62,14 @@ const (
 如果用户同意授权，页面将跳转至 redirect_uri/?code=CODE&state=STATE
 
 See: https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_webpage_authorization.html
+
+GET https://open.weixin.qq.com/connect/oauth2/authorize?appid=wxf0e81c3bee622d60&redirect_uri=http%3A%2F%2Fnba.bluewebgame.com%2Foauth_response.php&response_type=code&scope=snsapi_userinfo&state=STATE#wechat_redirect
 */
 func GetAuthorizeUrl(appid string, redirectUri string, scope string, state string) (authorizeUrl string) {
 	params := url.Values{}
 	params.Add("appid", appid)
-	params.Add("redirectUri", redirectUri)
+	params.Add("redirect_uri", redirectUri)
+	params.Add("response_type", "code")
 	params.Add("scope", scope)
 	params.Add("state", state)
 	return OauthAuthorizeServerUrl + apiAuthorize + "?" + params.Encode()
@@ -161,7 +164,7 @@ const (
 type OauthUserInfo struct {
 	Openid     string   `json:"openid"`
 	Nickname   string   `json:"nickname"`
-	Sex        string   `json:"sex"`
+	Sex        int64    `json:"sex"`
 	Province   string   `json:"province"`
 	City       string   `json:"city"`
 	Country    string   `json:"country"`

--- a/apis/oauth/oauth_test.go
+++ b/apis/oauth/oauth_test.go
@@ -126,15 +126,15 @@ func TestGetAuthorizeUrl(t *testing.T) {
 		args             args
 		wantAuthorizeUrl string
 	}{
-		{name: "case1", args: args{appid: "appid", redirectUri: "https://fastwego.dev/api/weixin/oauth", scope: ScopeSnsapiUserinfo, state: "STATE"}, wantAuthorizeUrl: "https://open.weixin.qq.com/connect/oauth2/authorize?appid=appid&redirectUri=https%3A%2F%2Ffastwego.dev%2Fapi%2Fweixin%2Foauth&scope=snsapi_userinfo&state=STATE"},
-		{name: "case2", args: args{appid: "appid", redirectUri: "https://fastwego.dev/api/weixin/oauth", scope: ScopeSnsapiBase, state: "STATE"}, wantAuthorizeUrl: "https://open.weixin.qq.com/connect/oauth2/authorize?appid=appid&redirectUri=https%3A%2F%2Ffastwego.dev%2Fapi%2Fweixin%2Foauth&scope=snsapi_base&state=STATE"},
+		{name: "case1", args: args{appid: "appid", redirectUri: "https://fastwego.dev/api/weixin/oauth", scope: ScopeSnsapiUserinfo, state: "STATE"}, wantAuthorizeUrl: "https://open.weixin.qq.com/connect/oauth2/authorize?appid=appid&redirect_uri=https%3A%2F%2Ffastwego.dev%2Fapi%2Fweixin%2Foauth&response_type=code&scope=snsapi_userinfo&state=STATE"},
+		{name: "case2", args: args{appid: "appid", redirectUri: "https://fastwego.dev/api/weixin/oauth", scope: ScopeSnsapiBase, state: "STATE"}, wantAuthorizeUrl: "https://open.weixin.qq.com/connect/oauth2/authorize?appid=appid&redirect_uri=https%3A%2F%2Ffastwego.dev%2Fapi%2Fweixin%2Foauth&response_type=code&scope=snsapi_base&state=STATE"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotAuthorizeUrl := GetAuthorizeUrl(tt.args.appid, tt.args.redirectUri, tt.args.scope, tt.args.state)
 			fmt.Println(gotAuthorizeUrl)
 			if gotAuthorizeUrl != tt.wantAuthorizeUrl {
-				t.Errorf("GetAuthorizeUrl() = %v, want %v", gotAuthorizeUrl, tt.wantAuthorizeUrl)
+				t.Errorf("GetAuthorizeUrl() = %v \n want %v", gotAuthorizeUrl, tt.wantAuthorizeUrl)
 			}
 		})
 	}
@@ -146,7 +146,7 @@ func TestGetUserInfo(t *testing.T) {
 		_, _ = w.Write([]byte(`{   
           "openid":"OPENID",
 		  "nickname": "NICKNAME",
-		  "sex":"1",
+		  "sex":1,
 		  "province":"PROVINCE",
 		  "city":"CITY",
 		  "country":"COUNTRY",
@@ -170,7 +170,7 @@ func TestGetUserInfo(t *testing.T) {
 		{name: "case1", args: args{access_token: "", openid: "", lang: LANG_zh_CN}, wantOauthUserInfo: OauthUserInfo{
 			Openid:     "OPENID",
 			Nickname:   "NICKNAME",
-			Sex:        "1",
+			Sex:        1,
 			Province:   "PROVINCE",
 			City:       "CITY",
 			Country:    "COUNTRY",

--- a/client.go
+++ b/client.go
@@ -27,13 +27,11 @@ import (
 	"time"
 )
 
-/*
-微信 api 服务器地址
-*/
 var (
-	WXServerUrl                 = "https://api.weixin.qq.com"
-	NeedRefreshAccessTokenError = errors.New("access token invalid")
-	WXInvalidErrorCode          = map[int64]string{40001: "access_token 无效", 40014: "不合法的access_token"}
+	WXServerUrl = "https://api.weixin.qq.com" // 微信 api 服务器地址
+	UserAgent   = "[fastwego/offiaccount] A fast wechat offiaccount development sdk written in Golang"
+
+	errorAccessTokenExpire = errors.New("access token expire")
 )
 
 /*
@@ -49,37 +47,14 @@ func (client *Client) HTTPGet(uri string) (resp []byte, err error) {
 	if err != nil {
 		return
 	}
-	if client.Ctx.Logger != nil {
-		client.Ctx.Logger.Printf("GET %s", uri)
-	}
-	response, err := http.Get(WXServerUrl + newUrl)
+
+	req, err := http.NewRequest(http.MethodGet, WXServerUrl+newUrl, nil)
 	if err != nil {
 		return
 	}
-	defer response.Body.Close()
-	resp, err = responseFilter(response)
+	req.Header.Add("User-Agent", UserAgent)
 
-	if err == NeedRefreshAccessTokenError {
-		_, err := client.Ctx.AccessToken.GetRefreshAccessTokenHandler(client.Ctx)
-		if err != nil {
-			return
-		}
-
-		newUrl, err = client.applyAccessToken(uri)
-		if err != nil {
-			return
-		}
-		if client.Ctx.Logger != nil {
-			client.Ctx.Logger.Printf("Refresh Access Token Second GET %s", newUrl)
-		}
-		response, err := http.Get(WXServerUrl + newUrl)
-		if err != nil {
-			return
-		}
-		defer response.Body.Close()
-		return responseFilter(response)
-	}
-	return
+	return client.HTTPDo(req)
 }
 
 //HTTPPost POST 请求
@@ -88,36 +63,65 @@ func (client *Client) HTTPPost(uri string, payload io.Reader, contentType string
 	if err != nil {
 		return
 	}
-	if client.Ctx.Logger != nil {
-		client.Ctx.Logger.Printf("POST %s", uri)
+
+	req, err := http.NewRequest(http.MethodPost, WXServerUrl+newUrl, payload)
+	if err != nil {
+		return
 	}
-	response, err := http.Post(WXServerUrl+newUrl, contentType, payload)
+	req.Header.Add("User-Agent", UserAgent)
+	req.Header.Add("Content-Type", contentType)
+
+	return client.HTTPDo(req)
+}
+
+//HTTPDo 执行 请求
+func (client *Client) HTTPDo(req *http.Request) (resp []byte, err error) {
+	if client.Ctx.Logger != nil {
+		client.Ctx.Logger.Printf("%s %s Headers %v", req.Method, req.URL.String(), req.Header)
+	}
+
+	response, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return
 	}
 	defer response.Body.Close()
+
 	resp, err = responseFilter(response)
 
-	if err == NeedRefreshAccessTokenError {
-		_, err := client.Ctx.AccessToken.GetRefreshAccessTokenHandler(client.Ctx)
+	// 发现 access_token 过期
+	if err == errorAccessTokenExpire {
+
+		// 主动 通知 access_token 过期
+		err = client.Ctx.AccessToken.NoticeAccessTokenExpireHandler(client.Ctx)
 		if err != nil {
 			return
 		}
 
-		newUrl, err = client.applyAccessToken(uri)
+		// 通知到位后 access_token 会被刷新，那么可以 retry 了
+		var accessToken string
+		accessToken, err = client.Ctx.AccessToken.GetAccessTokenHandler(client.Ctx)
 		if err != nil {
 			return
 		}
+
+		// 换新装
+		q := req.URL.Query()
+		q.Set("access_token", accessToken)
+		req.URL.RawQuery = q.Encode()
+
 		if client.Ctx.Logger != nil {
-			client.Ctx.Logger.Printf("Refresh Access Token Second POST %s", newUrl)
+			client.Ctx.Logger.Printf("retry %s %s Headers %v", req.Method, req.URL.String(), req.Header)
 		}
-		response, err := http.Post(WXServerUrl+newUrl, contentType, payload)
+
+		response, err = http.DefaultClient.Do(req)
 		if err != nil {
 			return
 		}
 		defer response.Body.Close()
-		return responseFilter(response)
+
+		resp, err = responseFilter(response)
 	}
+
 	return
 }
 
@@ -164,8 +168,9 @@ func responseFilter(response *http.Response) (resp []byte, err error) {
 		return
 	}
 
-	if _, ok := WXInvalidErrorCode[errorResponse.Errcode]; ok {
-		err = NeedRefreshAccessTokenError
+	// 42001 - access_token 超时，请检查 access_token 的有效期，请参考基础支持 - 获取 access_token 中，对 access_token 的详细机制说明
+	if errorResponse.Errcode == 42001 {
+		err = errorAccessTokenExpire
 		return
 	}
 	if errorResponse.Errcode != 0 {
@@ -205,8 +210,7 @@ func GetAccessToken(ctx *OffiAccount) (accessToken string, err error) {
 	}
 
 	// 提前过期 提供冗余时间
-	expiresIn = int(0.9 * float64(expiresIn))
-	d := time.Duration(expiresIn) * time.Second
+	d := time.Duration(expiresIn-300) * time.Second
 	_ = ctx.AccessToken.Cache.Save(ctx.Config.Appid, accessToken, d)
 
 	if ctx.Logger != nil {
@@ -217,34 +221,17 @@ func GetAccessToken(ctx *OffiAccount) (accessToken string, err error) {
 }
 
 /*
-从 公众号实例 的 AccessToken 管理器 更新 access_token
+NoticeAccessTokenExpire 只需将本地存储的 access_token 删除，即完成了 access_token 已过期的 主动通知
 
-获得新的 access_token 后 过期时间设置为 0.9 * expiresIn 提供一定冗余
+retry 请求的时候，会发现本地没有 access_token ，从而触发refresh
 */
-func NoticeRefreshAccessToken(ctx *OffiAccount) (accessToken string, err error) {
-	refreshAccessTokenLock.Lock()
-	defer refreshAccessTokenLock.Unlock()
-
-	accessToken, expiresIn, err := refreshAccessTokenFromWXServer(ctx.Config.Appid, ctx.Config.Secret)
-	if err != nil {
-		return
-	}
-
-	// 提前过期 提供冗余时间
-	expiresIn = int(0.9 * float64(expiresIn))
-	d := time.Duration(expiresIn) * time.Second
-	_ = ctx.AccessToken.Cache.Save(ctx.Config.Appid, accessToken, d)
-
+func NoticeAccessTokenExpire(ctx *OffiAccount) (err error) {
 	if ctx.Logger != nil {
-		ctx.Logger.Printf("%s %s %d\n", "refreshAccessTokenFromWXServer", accessToken, expiresIn)
+		ctx.Logger.Println("NoticeAccessTokenExpire")
 	}
 
-	// 可以做一些别的事情
-	// 如：通知 中控服务，让中控处理更新自己的 accessToken， 中控接收到请求后，对比中控缓存的accessToken时候更新accessToken，注意并发读写问题
-	// do something ...
-
+	err = ctx.AccessToken.Cache.Delete(ctx.Config.Appid)
 	return
-
 }
 
 /*

--- a/client_test.go
+++ b/client_test.go
@@ -62,11 +62,11 @@ func TestClient_getAccessToken(t *testing.T) {
 			gotAccessToken, err := GetAccessToken(client.Ctx)
 			fmt.Println(gotAccessToken, err)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("getAccessToken() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetAccessToken() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if gotAccessToken != tt.wantAccessToken {
-				t.Errorf("getAccessToken() gotAccessToken = %v, want %v", gotAccessToken, tt.wantAccessToken)
+				t.Errorf("GetAccessToken() gotAccessToken = %v, want %v", gotAccessToken, tt.wantAccessToken)
 			}
 		})
 	}

--- a/offiaccount.go
+++ b/offiaccount.go
@@ -30,8 +30,8 @@ import (
 // GetAccessTokenFunc 获取 access_token 方法接口
 type GetAccessTokenFunc func(ctx *OffiAccount) (accessToken string, err error)
 
-// NoticeRefreshAccessTokenFunc 通知中控 刷新 access_token
-type NoticeRefreshAccessTokenFunc func(ctx *OffiAccount) (accessToken string, err error)
+// NoticeAccessTokenExpireFunc 通知中控 刷新 access_token
+type NoticeAccessTokenExpireFunc func(ctx *OffiAccount) (err error)
 
 /*
 OffiAccount 公众号实例
@@ -48,9 +48,9 @@ type OffiAccount struct {
 AccessToken 管理器 处理缓存 和 刷新 逻辑
 */
 type AccessToken struct {
-	Cache                        cachego.Cache
-	GetAccessTokenHandler        GetAccessTokenFunc
-	GetRefreshAccessTokenHandler NoticeRefreshAccessTokenFunc
+	Cache                          cachego.Cache
+	GetAccessTokenHandler          GetAccessTokenFunc
+	NoticeAccessTokenExpireHandler NoticeAccessTokenExpireFunc
 }
 
 /*
@@ -70,16 +70,16 @@ func New(config Config) (offiAccount *OffiAccount) {
 	instance := OffiAccount{
 		Config: config,
 		AccessToken: AccessToken{
-			Cache:                        file.New(os.TempDir()),
-			GetAccessTokenHandler:        GetAccessToken,
-			GetRefreshAccessTokenHandler: NoticeRefreshAccessToken,
+			Cache:                          file.New(os.TempDir()),
+			GetAccessTokenHandler:          GetAccessToken,
+			NoticeAccessTokenExpireHandler: NoticeAccessTokenExpire,
 		},
 	}
 
 	instance.Client = Client{Ctx: &instance}
 	instance.Server = Server{Ctx: &instance}
 
-	instance.Logger = log.New(os.Stdout, "[offiaccount] ", log.LstdFlags)
+	instance.Logger = log.New(os.Stdout, "[fastwego/offiaccount] ", log.LstdFlags|log.Llongfile)
 
 	return &instance
 }
@@ -100,6 +100,17 @@ SetGetAccessTokenHandler 设置 AccessToken 获取方法。默认 从本地缓�
 */
 func (offiAccount *OffiAccount) SetGetAccessTokenHandler(f GetAccessTokenFunc) {
 	offiAccount.AccessToken.GetAccessTokenHandler = f
+}
+
+/*
+SetNoticeAccessTokenExpireHandler 设置 AccessToken 过期 通知
+
+框架提供的默认机制是 删除本地缓存的 access_token，那么 retry 的时候 会触发 刷新
+
+如果有多实例服务，可以设置为 通知 中控服务器 去刷新
+*/
+func (offiAccount *OffiAccount) SetNoticeAccessTokenExpireHandler(f NoticeAccessTokenExpireFunc) {
+	offiAccount.AccessToken.NoticeAccessTokenExpireHandler = f
 }
 
 /*


### PR DESCRIPTION

- 新增 HTTPDo 方法，作为 Get/Post 的执行器，统一处理 `errorAccessTokenExpire`
- HTTPDo  在 responseFilter 处理后，发现 errorAccessTokenExpire：
    - 调用 `NoticeAccessTokenExpireHandler` 通知 中控 或 单机 处理事件：
        - 如果是中控模式，可以请求 url ，告诉中控即时刷新
        - 如果是单机模式，直接删除本地 access_token 缓存即可
    - 通知完后，就可以放心 retry，调用 `GetAccessTokenHandler` 获取新的 access_token：
        - 将 request 的 access_token 参数换成新的后，再次执行 http 请求
- 另外：
    - 错误类型 `errorAccessTokenExpire` 为内部变量，无需暴露
     - 根据文档，只有 errcode = 42001 明确是 expire 事件
